### PR TITLE
apt-key is deprecated in Ubuntu 22.04 and Debian Bullseye

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -100,7 +100,7 @@ to configure your system to read packages from the Regolith package repository a
 
 1. Register the Regolith public key to your local `apt`:
 ```bash
-wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo apt-key add -
+wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo tee /etc/apt/trusted.gpg.d/regolith.asc
 ```
 2. Add the repository URL to your local `apt`:
 ```bash

--- a/content/_index.md
+++ b/content/_index.md
@@ -71,7 +71,7 @@ to configure your system to read packages from the Regolith package repository a
 
 1. Register the Regolith public key to your local `apt`:
 ```bash
-wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo apt-key add -
+wget -qO - https://regolith-linux.github.io/package-repo/regolith.key | sudo tee /etc/apt/trusted.gpg.d/regolith.asc
 ```
 2. Add the repository URL to your local `apt`:
 ```bash


### PR DESCRIPTION
apt-key has been deprecated. Using it in Ubuntu 22.04/Debian bullseye emits warning.

apt-key will be removed after those releases.

The GPG repo key should now simply copied in /etc/apt/trusted.gpg.d/

installation lines were updated to reflect that.