### PR TITLE
Compositor doc

### DIFF
--- a/content/docs/howtos/customize-compositor.md
+++ b/content/docs/howtos/customize-compositor.md
@@ -26,7 +26,6 @@ WARNING: In Regolith 2.x, the default compositor is "no compositor". In
 Regolith 1.x, the default was Picom.
 {{< /hint >}}
 
-
 ## Finding available compositors
 
 The following command will list all compositors configured to work with
@@ -38,16 +37,15 @@ apt search regolith-compositor-
 
 You should find at least the following:
 
-* `regolith-compositor-none` **[default]**: No compositor. Best performance, no visual
+- `regolith-compositor-none` **[default]**: No compositor. Best performance, no visual
   effects.
-* `regolith-compositor-picom-glx`: Uses `picom`. Recommended for most users to
+- `regolith-compositor-picom-glx`: Uses `picom`. Recommended for most users to
   resolve screen tearing and add visual effects. Modern and well-maintained
   fork of `compton`. Was the default compositor in Regolith 1.6.
-* `regolith-compositor-compton-glx`: An ancestor of `picom` which is no longer
+- `regolith-compositor-compton-glx`: An ancestor of `picom` which is no longer
   maintained.
-* `regolith-compositor-xcompmgr`: An early compositor that may offer more
+- `regolith-compositor-xcompmgr`: An early compositor that may offer more
   consistent performance if more complex compositors are problematic.
-
 
 ## Installing a compositor
 
@@ -64,13 +62,12 @@ case we’ll install `picom`:
 apt install regolith-compositor-picom
 ```
 
-**Log out and then log back in** and the new compositor should be loaded.  You
+**Log out and then log back in** and the new compositor should be loaded. You
 can verify by checking the process list for `picom`:
 
 ```console
-ps aux | grep picom 
+ps aux | grep picom
 ```
-
 
 ## Overriding Regolith default compositor configuration
 

--- a/content/docs/howtos/customize-compositor.md
+++ b/content/docs/howtos/customize-compositor.md
@@ -54,7 +54,7 @@ You should find at least the following:
 {{< hint info >}}
 Due to the way that the compositor is managed by i3-wm, you must log out and
 back in for compositor changes to take effect. Restarting i3 is not sufficient.
-{{< hint info >}}
+{{< /hint >}}
 
 Run the following package install command to swap out the compositor. In this
 case we’ll install `picom`:

--- a/content/docs/howtos/customize-compositor.md
+++ b/content/docs/howtos/customize-compositor.md
@@ -52,8 +52,9 @@ You should find at least the following:
 ## Installing a compositor
 
 {{< hint info >}}
-Due to the way that the compositor is managed by i3-wm, you must log out and
-back in for compositor changes to take effect. Restarting i3 is not sufficient.
+Due to the way that the compositor is managed by i3-wm, **you must log out and
+back in for compositor changes to take effect**. Restarting i3 is not
+sufficient.
 {{< /hint >}}
 
 Run the following package install command to swap out the compositor. In this

--- a/content/docs/howtos/customize-compositor.md
+++ b/content/docs/howtos/customize-compositor.md
@@ -37,8 +37,8 @@ apt search regolith-compositor-
 
 You should find at least the following:
 
-- `regolith-compositor-none` **[default]**: No compositor. Best performance, no visual
-  effects.
+- `regolith-compositor-none` **[default]**: No compositor. Best performance, no
+  visual effects.
 - `regolith-compositor-picom-glx`: Uses `picom`. Recommended for most users to
   resolve screen tearing and add visual effects. Modern and well-maintained
   fork of `compton`. Was the default compositor in Regolith 1.6.

--- a/content/docs/howtos/customize-compositor.md
+++ b/content/docs/howtos/customize-compositor.md
@@ -5,10 +5,76 @@ description: >
   How to customize Regolith's compositor
 ---
 
-{{< hint warning >}}
-This page is under construction
+# How to customize your compositor (visual effects)
 
-TODO: What is the default compositor in Regolith 2.0?
+{{< hint info >}}
+Pay special attention to this section if you are experiencing odd visual
+glitches or slow graphics performance.
 {{< /hint >}}
 
-1.6 doc: <https://regolith-linux.org/docs/customize/compositors/>
+A compositor is a UI component that applies visual effects to windows before
+they are rendered on-screen. Many desktop environments integrate a compositor
+directly into the window manager, making it difficult to switch out or disable.
+In Regolith, the compositor is defined as a pluggable “extension point” in the
+packaging system. This means that compositors can be switched out simply by
+installing the packages that contain them. The underlying packaging system will
+ensure there are no conflicts and that all the dependencies of a given
+compositor are also installed.
+
+{{< hint warning >}}
+WARNING: In Regolith 2.x, the default compositor is "no compositor". In
+Regolith 1.x, the default was Picom.
+{{< /hint >}}
+
+
+## Finding available compositors
+
+The following command will list all compositors configured to work with
+Regolith:
+
+```console
+apt search regolith-compositor-
+```
+
+You should find at least the following:
+
+* `regolith-compositor-none` **[default]**: No compositor. Best performance, no visual
+  effects.
+* `regolith-compositor-picom-glx`: Uses `picom`. Recommended for most users to
+  resolve screen tearing and add visual effects. Modern and well-maintained
+  fork of `compton`. Was the default compositor in Regolith 1.6.
+* `regolith-compositor-compton-glx`: An ancestor of `picom` which is no longer
+  maintained.
+* `regolith-compositor-xcompmgr`: An early compositor that may offer more
+  consistent performance if more complex compositors are problematic.
+
+
+## Installing a compositor
+
+{{< hint info >}}
+Due to the way that the compositor is managed by i3-wm, you must log out and
+back in for compositor changes to take effect. Restarting i3 is not sufficient.
+{{< hint info >}}
+
+Run the following package install command to swap out the compositor. In this
+case we’ll install `picom`:
+
+```console
+apt install regolith-compositor-picom
+```
+
+**Log out and then log back in** and the new compositor should be loaded.  You
+can verify by checking the process list for `picom`:
+
+```console
+ps aux | grep picom 
+```
+
+
+## Overriding Regolith default compositor configuration
+
+### Compton/Picom
+
+To provide your own Compton/Picom compositor config, copy the default or create
+your own and save it as `~/.config/regolith2/picom/config`. Upon next session it
+will be loaded instead of the default config `/etc/regolith/picom/config`.


### PR DESCRIPTION
Populate a compositor doc based on 1.6 docs. Noted the change in default compositor to `none`.