### PR TITLE
Fix config path in a doc page

### DIFF
--- a/content/docs/howtos/customize-i3-configuration.fr.md
+++ b/content/docs/howtos/customize-i3-configuration.fr.md
@@ -9,7 +9,7 @@ description: >
 # Comment personnaliser la configuration de i3 avec Regolith
 
 Les configurations par défaut sont stockées dans `/usr/share/regolith/i3/config.d`.
-Ces fichiers sont chargés de selon l'ordre alphabétique. Ensuite, les configurations de l'utilisateur dans `~/.config/regolith2/config.d` sont chargées, également dans l'ordre alphabétique.
+Ces fichiers sont chargés de selon l'ordre alphabétique. Ensuite, les configurations de l'utilisateur dans `~/.config/regolith2/i3/config.d` sont chargées, également dans l'ordre alphabétique.
 La configuration par défaut de Regolith est faite pour être modifiée en utilisant des variables `Xresources`, en ajoutant des configurations utilisateurs ou en ajoutant/supprimant les configurations par défaut avec `apt`.
 Pour cette raison, il y a plusieurs manières de personnaliser i3 dans Regolith. Ces manières peuvent être utilisées conjointement ou séparement pour avoir une configuration propre:
 

--- a/content/docs/howtos/customize-i3-configuration.md
+++ b/content/docs/howtos/customize-i3-configuration.md
@@ -8,7 +8,7 @@ description: >
 
 # How to work with Regolith 2's defaults
 
-The default configurations are stored in `/usr/share/regolith/i3/config.d`. These are loaded alphabetically. Then user configurations in `~/.config/regolith2/config.d` are loaded, also in alphabetical order. Regolith's default configuration is built to be customized by setting `Xresources` variables, adding user configuration, and adding or removing default configurations via `apt`. For this reason, there are several approaches to customization of i3 in Regolith that can be used separately or in combination to achieve your configuration cleanly:
+The default configurations are stored in `/usr/share/regolith/i3/config.d`. These are loaded alphabetically. Then user configurations in `~/.config/regolith2/i3/config.d` are loaded, also in alphabetical order. Regolith's default configuration is built to be customized by setting `Xresources` variables, adding user configuration, and adding or removing default configurations via `apt`. For this reason, there are several approaches to customization of i3 in Regolith that can be used separately or in combination to achieve your configuration cleanly:
 
 - Use `Xresources` to override variables, e.g. keybindings, strings, program names, colors, etc.
 - Add or remove Regolith default configuration files with `apt`


### PR DESCRIPTION
I fixed the configuration directory path in the page "Customize i3 Configuration".