### PR TITLE
Fix path pointing to user i3 config

### DIFF
--- a/content/docs/howtos/customize-i3-configuration.md
+++ b/content/docs/howtos/customize-i3-configuration.md
@@ -8,7 +8,7 @@ description: >
 
 # How to work with Regolith 2's defaults
 
-The default configurations are stored in `/usr/share/regolith/i3/config.d`. These are loaded alphabetically. Then user configurations in `~/.config/regolith2/config.d` are loaded, also in alphabetical order. Regolith's default configuration is built to be customized by setting `Xresources` variables, adding user configuration, and adding or removing default configurations via `apt`. For this reason, there are several approaches to customization of i3 in Regolith that can be used separately or in combination to achieve your configuration cleanly:
+The default configurations are stored in `/usr/share/regolith/i3/config.d`. These are loaded alphabetically. Then user configurations in `~/.config/regolith2/i3/config.d` are loaded, also in alphabetical order. Regolith's default configuration is built to be customized by setting `Xresources` variables, adding user configuration, and adding or removing default configurations via `apt`. For this reason, there are several approaches to customization of i3 in Regolith that can be used separately or in combination to achieve your configuration cleanly:
 
 - Use `Xresources` to override variables, e.g. keybindings, strings, program names, colors, etc.
 - Add or remove Regolith default configuration files with `apt`


### PR DESCRIPTION
I believe there's a small typo in the documentation. I couldn't figure out why my i3 configs weren't applied, I think that's why.