### PR TITLE
Update Ubuntu base version listed on Regolith 2.2 download

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -210,7 +210,7 @@ The `regolith-compositor-picom-glx` compositor should work on most computers. If
 {{< /tab >}}
 {{< tab "Regolith Linux 2.2 ISO" >}} 
 
-Regolith Linux is the Regolith Desktop environment installed into a customized Ubuntu 22.04 installer image.  It allows one to boot from a USB drive to run Regolith without having to install it. It also allows to install the system onto a computer's drive.  Regolith Linux has the following features in addition to the Regolith Desktop:
+Regolith Linux is the Regolith Desktop environment installed into a customized Ubuntu 22.10 installer image.  It allows one to boot from a USB drive to run Regolith without having to install it. It also allows to install the system onto a computer's drive.  Regolith Linux has the following features in addition to the Regolith Desktop:
 
 * Regolith-branded boot and login screens
 * Uses the `lightdm` display manager over `gdm3` to avoid unneeded dependencies


### PR DESCRIPTION
Regolith 2.2 is built on Ubuntu 22.10, not Ubuntu 22.04 as mentioned on this page. The link is to an Ubuntu 22.10 image.