### PR TITLE
regolith 3.0 xres key names

### DIFF
--- a/content/docs/howtos/change-lockscreen.md
+++ b/content/docs/howtos/change-lockscreen.md
@@ -16,12 +16,16 @@ $ gsettings set org.gnome.gnome-flashback screensaver false
 
 Specify the following override line in your `~/.config/regolith3/Xresources` file (substituting `your-script.sh` with the command you wish to use for the locking your screen):
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 ```toml
-i3-wm.program.lock: your-script.sh
+wm.program.lock: your-script.sh
 ```
 
 For example, assuming you have `i3lock` installed:
 
 ```console
-$ echo "i3-wm.program.lock: /usr/bin/i3lock" >> ~/.config/regolith3/Xresources
+$ echo "wm.program.lock: /usr/bin/i3lock" >> ~/.config/regolith3/Xresources
 ```

--- a/content/docs/howtos/change-workspace-icons.md
+++ b/content/docs/howtos/change-workspace-icons.md
@@ -31,8 +31,12 @@ Follow these steps to override the default workspace label with your own:
 1. Find the character you want to use and copy to the clipboard. This example will use the Sigma glyph from Material Design Icons font ().
 2. Add a line to your `Xresources` overrides file with the workspace number and character you wish to use:
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 ```console
-$ echo "i3-wm.workspace.06.name: 6:" >> ~/.config/regolith3/Xresources
+$ echo "wm.workspace.06.name: 6:" >> ~/.config/regolith3/Xresources
 ```
 
 3. Refresh your UI:
@@ -50,9 +54,9 @@ In i3, workspace labels are only updated when a workspace is created. Ensure you
 The same approach can be used to specify textual descriptions of your workspaces. For example, adding the following lines to your `~/.config/regolith3/Xresources` file will change the first three workspaces:
 
 ```
-i3-wm.workspace.01.name: 1: Terminal
-i3-wm.workspace.02.name: 2: Web
-i3-wm.workspace.03.name: 3: Chat
+wm.workspace.01.name: 1: Terminal
+wm.workspace.02.name: 2: Web
+wm.workspace.03.name: 3: Chat
 ```
 
 ### Adding support for icon fonts in text editors

--- a/content/docs/howtos/customize-i3-configuration.fr.md
+++ b/content/docs/howtos/customize-i3-configuration.fr.md
@@ -20,10 +20,14 @@ Pour cette raison, il y a plusieurs manières de personnaliser i3 dans Regolith.
 
 ## Comment fixer une variable `Xresources`
 
-La configuration dans l'exemple suivant (récupérée de `/usr/share/regolith/i3/config.d/80_compositor`) peut être modifiée pour charger le compositor que l'on veut sans modifier ou ré-écrire la configuration existante de i3 en fixant la variable $i3-wm.program.compositor`.
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
+La configuration dans l'exemple suivant (récupérée de `/usr/share/regolith/i3/config.d/80_compositor`) peut être modifiée pour charger le compositor que l'on veut sans modifier ou ré-écrire la configuration existante de i3 en fixant la variable $wm.program.compositor`.
 
 ```
-set_from_resource $i3-wm.program.compositor i3-wm.program.compositor /usr/share/regolith-compositor/init
+set_from_resource $wm.program.compositor wm.program.compositor /usr/share/regolith-compositor/init
 exec_always --no-startup-id $i3-wm.program.compositor
 ```
 
@@ -31,21 +35,21 @@ Pour faire cela, ajouter simplement une ligne à `~/.config/regolith3/Xresources
 
 ```
 # Utiliser mon propre programme compositor
-i3-wm.program.compositor: /usr/local/bin/my-compositor
+wm.program.compositor: /usr/local/bin/my-compositor
 ```
 
 De la même manière, vous pouvez ré-écrire d'autres paramètres i3 avec `Xresources` en utilisant les noms de variables trouvés dans les fichiers du dossier `/usr/share/regolith/i3/config.d`:
 
 ```
 ## Configurer les espacements
-i3-wm.gaps.inner.size: 1
+wm.gaps.inner.size: 1
 
 ## Configurer les bordures
-i3-wm.window.border.size: 3
-i3-wm.client.focused.color.child_border: #AAD3E9
+wm.window.border.size: 3
+wm.client.focused.color.child_border: #AAD3E9
 
 ## Configurer les noms des espaces de travail
-i3-wm.workspace.01.name: 1:FOO
+wm.workspace.01.name: 1:FOO
 ```
 
 Pour plus de détails, merci de lire [la documentation concernant `Xresources`]({{< ref "docs/howtos/override-xres.md" >}}).

--- a/content/docs/howtos/customize-i3-configuration.md
+++ b/content/docs/howtos/customize-i3-configuration.md
@@ -6,7 +6,7 @@ description: >
   How to make changes to the way i3 looks and behaves.
 ---
 
-# How to work with Regolith 2's defaults
+# How to work with Regolith's defaults
 
 The default configurations are stored in `/usr/share/regolith/i3/config.d`. These are loaded alphabetically. Then user configurations in `~/.config/regolith3/i3/config.d` are loaded, also in alphabetical order. Regolith's default configuration is built to be customized by setting `Xresources` variables, adding user configuration, and adding or removing default configurations via `apt`. For this reason, there are several approaches to customization of i3 in Regolith that can be used separately or in combination to achieve your configuration cleanly:
 
@@ -17,32 +17,36 @@ The default configurations are stored in `/usr/share/regolith/i3/config.d`. Thes
 
 ## How to set an `Xresources` variable
 
-The following configuration example (from `/usr/share/regolith/i3/config.d/80_compositor`) can be customized to load whatever compositor you want, without editing or overriding the existing i3 configuration file, by setting `$i3-wm.program.compositor`.
+The following configuration example (from `/usr/share/regolith/i3/config.d/80_compositor`) can be customized to load whatever compositor you want, without editing or overriding the existing i3 configuration file, by setting `$wm.program.compositor`.
+
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
 
 ```
-set_from_resource $i3-wm.program.compositor i3-wm.program.compositor /usr/share/regolith-compositor/init
-exec_always --no-startup-id $i3-wm.program.compositor
+set_from_resource $wm.program.compositor wm.program.compositor /usr/share/regolith-compositor/init
+exec_always --no-startup-id $wm.program.compositor
 ```
 
 To do this, simply add a line to `~/.config/regolith3/Xresources` like:
 
 ```
 # Use my own home-made compositor
-i3-wm.program.compositor: /usr/local/bin/my-compositor
+wm.program.compositor: /usr/local/bin/my-compositor
 ```
 
 Similarly, you can override other i3 options with `Xresources` based on the variable names found in `/usr/share/regolith/i3/config.d` files:
 
 ```
 ## Gap configuration
-i3-wm.gaps.inner.size: 1
+wm.gaps.inner.size: 1
 
 ## Border configuration
-i3-wm.window.border.size: 3
-i3-wm.client.focused.color.child_border: #AAD3E9
+wm.window.border.size: 3
+wm.client.focused.color.child_border: #AAD3E9
 
 ## Workspace names
-i3-wm.workspace.01.name: 1:FOO
+wm.workspace.01.name: 1:FOO
 ```
 
 For more, please [read a more in-depth discussion on `Xresources`]({{< ref "docs/howtos/override-xres.md" >}})
@@ -109,7 +113,7 @@ sudo apt remove regolith-i3-workspace-config
 
 Finally, **restart i3 or log out and back in**.
 
-## How to replace Regolith's defaults wholesale
+## How to replace Regolith's defaults completely
 
 If you don't want to keep any of Regolith's defaults (for example, you're an
 experienced `i3` user with a complete personal config you want to use), you can

--- a/content/docs/howtos/default-gap.md
+++ b/content/docs/howtos/default-gap.md
@@ -4,12 +4,16 @@ description: >
   Change the pixels between windows.
 ---
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 Like most configuration in Regolith, the i3-gaps gap size can be tuned via `Xresources` ([See here]({{< ref "/docs/Reference/xresources.md" >}}) for all Xresource definitions).
 
 1. Create or add the following value to your `~/.config/regolith3/Xresources` file:
 
 ```console
-i3-wm.gaps.inner.size: 20
+wm.gaps.inner.size: 20
 ```
 
 In this example we're setting the default gap to 20 pixels.

--- a/content/docs/howtos/hide-i3-bar-by-default.md
+++ b/content/docs/howtos/hide-i3-bar-by-default.md
@@ -4,13 +4,13 @@ description: >
   Hide i3-bar by default
 ---
 
-{{< hint danger >}}
-NOTICE: This page was copied from the [Regolith 1.x website](https://regolith-linux.org) and has not been updated for Regolith 2.  It may contain out of date information.
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
 {{< /hint >}}
 
 Add the line
 ```
-i3-wm.bar.mode: hide
+wm.bar.mode: hide
 ```
-to `$HOME/.config/regolith2/Xresources` file.
+to `$HOME/.config/regolith3/Xresources` file.
 The next time you log in the bar should be hidden by default.

--- a/content/docs/howtos/override-xres.fr.md
+++ b/content/docs/howtos/override-xres.fr.md
@@ -4,8 +4,8 @@ description: >
   Apprenez à organiser des copies utilisateur des fichiers de configuration Regolith
 ---
 
-{{< hint danger >}}
-NOTE: Cette page a été copiée depuis le site de [Regolith 1.x](https://regolith-linux.org) et n'a pas été mise à jour pour Regolith 2. Elle peut contenir des informations qui ne sont plus d'actualité.
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
 {{< /hint >}}
 
 Regolith repose sur le système [Xresources](https://en.wikipedia.org/wiki/X_resources) pour fournir une interface de configuration solide.
@@ -73,8 +73,8 @@ $ regolith-look refresh
 
 ```console
 $ xrdb -query | grep position
-i3-wm.bar.position:	bottom
-$ echo "i3-wm.bar.position:	top" >> ~/.config/regolith3/Xresources
+wm.bar.position:	bottom
+$ echo "wm.bar.position:	top" >> ~/.config/regolith3/Xresources
 $ regolith-look refresh
 ```
 
@@ -90,15 +90,15 @@ $ regolith-look refresh
 ### Exemple - Désactiver la barre d'état
 
 ```console
-$ echo "i3-wm.bar.trayoutput:	none" >> ~/.config/regolith3/Xresources
+$ echo "wm.bar.trayoutput:	none" >> ~/.config/regolith3/Xresources
 $ regolith-look refresh
 ```
 
 ### Exemple - Utiliser Alt plutôt que la touche Win comme touche Super
 
 ```console
-$ echo "i3-wm.mod: Mod1" >> ~/.config/regolith3/Xresources
-$ echo "i3-wm.alt: Mod4" >> ~/.config/regolith3/Xresources
+$ echo "wm.mod: Mod1" >> ~/.config/regolith3/Xresources
+$ echo "wm.alt: Mod4" >> ~/.config/regolith3/Xresources
 ```
 
 Ensuite, recharger i3 pour que le changement prenne effet.
@@ -108,7 +108,7 @@ Ensuite, recharger i3 pour que le changement prenne effet.
 Certains utilisateurs préfèrent utiliser l'application `nm-applet` pour configurer et gérer le réseau sans-fil (depuis Regolith 1.5, `nm-applet` est exécuté par défaut en arrière-plan). Le fichier de configuration i3 peut être modifié pour lancer certains programmes au lancement. Mais, plutôt que de copier tout le fichier, il est possible de fixer jusqu'à trois programmes via Xresources sans avoir à changer le fichier de configuration i3. Pour cela, assurez-vous que la barre d'état système est activé (voir ci-dessus).
 
 ```console
-$ echo "i3-wm.program.1: /usr/bin/nm-applet" >> ~/.config/regolith3/Xresources
+$ echo "wm.program.1: /usr/bin/nm-applet" >> ~/.config/regolith3/Xresources
 ```
 
 Ce changement nécessite que vous vous déconnectiez puir reconnectiez pour prendre effet.

--- a/content/docs/howtos/override-xres.md
+++ b/content/docs/howtos/override-xres.md
@@ -36,7 +36,7 @@ gtk.font_name:	Bitstream Vera Sans 12
 gtk.icon_theme_name:	Papirus-Dark
 gtk.monospace_font_name:	BitstreamVeraSansMono Nerd Font 13
 gtk.theme_name:	Ayu-Mirage-Dark
-i3-wm.bar.background.color:	#1F2430
+wm.bar.background.color:	#1F2430
 [...]
 ```
 
@@ -68,8 +68,8 @@ $ regolith-look refresh
 
 ```console
 $ xrdb -query | grep position
-i3-wm.bar.position:	bottom
-$ echo "i3-wm.bar.position:	top" >> ~/.config/regolith3/Xresources
+wm.bar.position:	bottom
+$ echo "wm.bar.position:	top" >> ~/.config/regolith3/Xresources
 $ regolith-look refresh
 ```
 
@@ -85,15 +85,15 @@ $ regolith-look refresh
 ### Example - Disable the System Tray
 
 ```console
-$ echo "i3-wm.bar.trayoutput:	none" >> ~/.config/regolith3/Xresources
+$ echo "wm.bar.trayoutput:	none" >> ~/.config/regolith3/Xresources
 $ regolith-look refresh
 ```
 
 ### Example - Use Alt instead of Win as Super
 
 ```console
-$ echo "i3-wm.mod: Mod1" >> ~/.config/regolith3/Xresources
-$ echo "i3-wm.alt: Mod4" >> ~/.config/regolith3/Xresources
+$ echo "wm.mod: Mod1" >> ~/.config/regolith3/Xresources
+$ echo "wm.alt: Mod4" >> ~/.config/regolith3/Xresources
 ```
 
 Then Reload i3 for the change to take effect.  Some settings may require logging back into the session, for example anything that i3 launches as a separate process.

--- a/content/docs/howtos/tdcli-blocklet.md
+++ b/content/docs/howtos/tdcli-blocklet.md
@@ -4,8 +4,8 @@ description: >
   Create and manage a to-do list from status bar
 ---
 
-{{< hint danger >}}
-NOTICE: This page was copied from the [Regolith 1.x website](https://regolith-linux.org) and has not been updated for Regolith 2.  It may contain out of date information.
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `wm.foo.bar` for Regolith 1.x and 2.x.
 {{< /hint >}}
 
 [`td-cli`](https://github.com/darrikonn/td-cli) is a command line todo manager written in Python3 for organizing todo lists across multiple projects.
@@ -46,14 +46,14 @@ bindsym $mod+Ctrl+d exec --no-startup-id "/usr/bin/gnome-terminal --class=floati
 Alternatively, you add these lines to your `i3` config file, first:
 
 ```console
-set_from_resource $i3-wm.bindsym.1 i3-wm.bindsym.1 :
-set_from_resource $i3-wm.bindsym.program.1 i3-wm.bindsym.program.1 :
-bindsym $mod+$i3-wm.bindsym.1 exec --no-startup-id "$i3-wm.bindsym.program.1"
+set_from_resource $wm.bindsym.1 wm.bindsym.1 :
+set_from_resource $wm.bindsym.program.1 wm.bindsym.program.1 :
+bindsym $mod+$wm.bindsym.1 exec --no-startup-id "$wm.bindsym.program.1"
 ```
 
 Then, add the followings to your `Xresources` file:
 
 ```console
-i3-wm.bindsym.1: Ctrl+d
-i3-wm.bindsym.program.1: /usr/bin/gnome-terminal --class=floating_window -e 'td --interactive'
+wm.bindsym.1: Ctrl+d
+wm.bindsym.program.1: /usr/bin/gnome-terminal --class=floating_window -e 'td --interactive'
 ```

--- a/content/docs/reference/xresources.de.md
+++ b/content/docs/reference/xresources.de.md
@@ -6,6 +6,10 @@ description: >
   All Regolith `Xresources` key definitions
 ---
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 | `Xresources` Key                                   | Description                                                                                                         |
 | -------------------------------------------------- | ------------------------------------------------------------------- |
 | gtk.theme_name                                     | GTK Theme   |
@@ -20,52 +24,52 @@ description: >
 | gnome.terminal.use-transparent-background          | Enables transparent background in gnome-terminal (`true / false`). See also `gnome.terminal.background-transparency-percent`. |
 | gnome.wallpaper                                    | GNOME Wallpaper (can be overridden in Settings)                                                                     |
 | gnome.wm.theme                                     | GNOME Window Manager Theme (unused)                                                                                 |
-| i3-wm.alt                                          | Key mapping for Alt key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.       |
-| i3-wm.bar.background.color                         | Bar Background Color                                                                                                |
-| i3-wm.bar.position                                 | Bar Screen Position                                                                                                 |
-| i3-wm.bar.separator.color                          | Color of seperator between blocks                                                                                   |
-| i3-wm.bar.statusline.color                         |                                                                                                                     |
-| i3-wm.bar.trayoutput                               | Enable or disable the [app tray](https://i3wm.org/docs/userguide.html#_tray_output) in i3bar                        |
-| i3-wm.bar.workspace.active.background.color        |                                                                                                                     |
-| i3-wm.bar.workspace.active.border.color            |                                                                                                                     |
-| i3-wm.bar.workspace.active.text.color              |                                                                                                                     |
-| i3-wm.bar.workspace.focused.background.color       |                                                                                                                     |
-| i3-wm.bar.workspace.focused.border.color           |                                                                                                                     |
-| i3-wm.bar.workspace.focused.text.color             |                                                                                                                     |
-| i3-wm.bar.workspace.inactive.background.color      |                                                                                                                     |
-| i3-wm.bar.workspace.inactive.border.color          |                                                                                                                     |
-| i3-wm.bar.workspace.inactive.text.color            |                                                                                                                     |
-| i3-wm.bar.workspace.urgent.background.color        |                                                                                                                     |
-| i3-wm.bar.workspace.urgent.border.color            |                                                                                                                     |
-| i3-wm.bar.workspace.urgent.text.color              |                                                                                                                     |
-| i3-wm.client.focused.color.background              |                                                                                                                     |
-| i3-wm.client.focused.color.border                  |                                                                                                                     |
-| i3-wm.client.focused.color.child_border            |                                                                                                                     |
-| i3-wm.client.focused.color.indicator               |                                                                                                                     |
-| i3-wm.client.focused.color.text                    |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.background     |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.border         |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.child_border   |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.indicator      |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.text           |                                                                                                                     |
-| i3-wm.client.unfocused.color.background            |                                                                                                                     |
-| i3-wm.client.unfocused.color.border                |                                                                                                                     |
-| i3-wm.client.unfocused.color.child_border          |                                                                                                                     |
-| i3-wm.client.unfocused.color.indicator             |                                                                                                                     |
-| i3-wm.client.unfocused.color.text                  |                                                                                                                     |
-| i3-wm.client.urgent.color.background               |                                                                                                                     |
-| i3-wm.client.urgent.color.border                   |                                                                                                                     |
-| i3-wm.client.urgent.color.child_border             |                                                                                                                     |
-| i3-wm.client.urgent.color.indicator                |                                                                                                                     |
-| i3-wm.client.urgent.color.text                     |                                                                                                                     |
-| i3-wm.floatingwindow.border.size                   | Window border size in pixels for floating windows                                                                   |
-| i3-wm.font                                         | Window manager font                                                                                                 |
-| i3-wm.gaps.inner.size                              | Default gap size between windows in pixels                                                                          |
-| i3-wm.gaps.outer.size                              | Default gap size at screen edge in pixels                                                                           |
-| i3-wm.mod                                          | Key mapping for Super key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.     |
-| i3-wm.window.border.size                           | Default border size in pixels                                                                                       |
-| i3-wm.workspace.01.name .. i3-wm.workspace.19.name | Workspace Labels                                                                                                    |
-| i3-wm.workspace.01.key .. i3-wm.workspace.10.key   | Workspace Shortucts                                                                                                 |
+| wm.alt                                          | Key mapping for Alt key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.       |
+| wm.bar.background.color                         | Bar Background Color                                                                                                |
+| wm.bar.position                                 | Bar Screen Position                                                                                                 |
+| wm.bar.separator.color                          | Color of seperator between blocks                                                                                   |
+| wm.bar.statusline.color                         |                                                                                                                     |
+| wm.bar.trayoutput                               | Enable or disable the [app tray](https://i3wm.org/docs/userguide.html#_tray_output) in i3bar                        |
+| wm.bar.workspace.active.background.color        |                                                                                                                     |
+| wm.bar.workspace.active.border.color            |                                                                                                                     |
+| wm.bar.workspace.active.text.color              |                                                                                                                     |
+| wm.bar.workspace.focused.background.color       |                                                                                                                     |
+| wm.bar.workspace.focused.border.color           |                                                                                                                     |
+| wm.bar.workspace.focused.text.color             |                                                                                                                     |
+| wm.bar.workspace.inactive.background.color      |                                                                                                                     |
+| wm.bar.workspace.inactive.border.color          |                                                                                                                     |
+| wm.bar.workspace.inactive.text.color            |                                                                                                                     |
+| wm.bar.workspace.urgent.background.color        |                                                                                                                     |
+| wm.bar.workspace.urgent.border.color            |                                                                                                                     |
+| wm.bar.workspace.urgent.text.color              |                                                                                                                     |
+| wm.client.focused.color.background              |                                                                                                                     |
+| wm.client.focused.color.border                  |                                                                                                                     |
+| wm.client.focused.color.child_border            |                                                                                                                     |
+| wm.client.focused.color.indicator               |                                                                                                                     |
+| wm.client.focused.color.text                    |                                                                                                                     |
+| wm.client.focused_inactive.color.background     |                                                                                                                     |
+| wm.client.focused_inactive.color.border         |                                                                                                                     |
+| wm.client.focused_inactive.color.child_border   |                                                                                                                     |
+| wm.client.focused_inactive.color.indicator      |                                                                                                                     |
+| wm.client.focused_inactive.color.text           |                                                                                                                     |
+| wm.client.unfocused.color.background            |                                                                                                                     |
+| wm.client.unfocused.color.border                |                                                                                                                     |
+| wm.client.unfocused.color.child_border          |                                                                                                                     |
+| wm.client.unfocused.color.indicator             |                                                                                                                     |
+| wm.client.unfocused.color.text                  |                                                                                                                     |
+| wm.client.urgent.color.background               |                                                                                                                     |
+| wm.client.urgent.color.border                   |                                                                                                                     |
+| wm.client.urgent.color.child_border             |                                                                                                                     |
+| wm.client.urgent.color.indicator                |                                                                                                                     |
+| wm.client.urgent.color.text                     |                                                                                                                     |
+| wm.floatingwindow.border.size                   | Window border size in pixels for floating windows                                                                   |
+| wm.font                                         | Window manager font                                                                                                 |
+| wm.gaps.inner.size                              | Default gap size between windows in pixels                                                                          |
+| wm.gaps.outer.size                              | Default gap size at screen edge in pixels                                                                           |
+| wm.mod                                          | Key mapping for Super key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.     |
+| wm.window.border.size                           | Default border size in pixels                                                                                       |
+| wm.workspace.01.name .. wm.workspace.19.name | Workspace Labels                                                                                                    |
+| wm.workspace.01.key .. wm.workspace.10.key   | Workspace Shortucts                                                                                                 |
 | i3xrocks.action.volume.left                        | Command to execute when volume indicator is left clicked (default: none)                                            |
 | i3xrocks.action.volume.middle                      | Command to execute when volume indicator is middle clicked (default: none)                                          |
 | i3xrocks.action.volume.right                       | Command to execute when volume indicator is right clicked (default: mute through amixer)                            |
@@ -113,25 +117,25 @@ The following `Xresources` keys are undefined by default but can be used by user
 
 | `Xresources` Key                  | Description                                                                                                                                                                                         |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| i3-wm.gaps.focus_follows_mouse    | The window under the mouse has focus if enabled                                                                                                                                                     |
-| i3-wm.program.launcher.app        | Command i3 executes from the app launcher keybinding                                                                                                                                                |
-| i3-wm.program.launcher.cmd        | Command i3 executes from the command launcher keybinding                                                                                                                                            |
-| i3-wm.program.launcher.window     | Command i3 executes for the window navigation keybinding                                                                                                                                            |
-| i3-wm.program.help                | Command to launch from the help keybinding                                                                                                                                                          |
-| i3-wm.program.file_search         | Command to launch from the file search keybinding                                                                                                                                                   |
-| i3-wm.program.refresh_ui          | Command to launch from the session refresh keybinding                                                                                                                                               |
-| i3-wm.program.logout              | Command to launch from the logout keybinding                                                                                                                                                        |
-| i3-wm.program.reboot              | Command to launch from the reboot keybinding                                                                                                                                                        |
-| i3-wm.program.shutdown            | Command to launch from the shutdown keybinding                                                                                                                                                      |
-| i3-wm.program.lock                | Command to launch from the lock screen keybinding                                                                                                                                                   |
-| i3-wm.program.sleep               | Command to launch from the sleep keybinding                                                                                                                                                         |
-| i3-wm.program.settings            | Command to launch from the Control Panel keybinding                                                                                                                                                 |
-| i3-wm.program.display             | Command to launch from the Display Settings keybinding                                                                                                                                              |
-| i3-wm.program.wifi                | Command to launch from the Wifi Settings keybinding                                                                                                                                                 |
-| i3-wm.program.bluetooth           | Command to launch from the Bluetooth Settings keybinding                                                                                                                                            |
-| i3-wm.program.files               | Command to launch from the file browser keybinding                                                                                                                                                  |
-| i3-wm.program.notification_ui     | Command to launch from the notification UI keybinding                                                                                                                                               |
-| i3-wm.program.1...i3-wm.program.3 | Optional programs to start with i3                                                                                                                                                                  |
+| wm.gaps.focus_follows_mouse    | The window under the mouse has focus if enabled                                                                                                                                                     |
+| wm.program.launcher.app        | Command i3 executes from the app launcher keybinding                                                                                                                                                |
+| wm.program.launcher.cmd        | Command i3 executes from the command launcher keybinding                                                                                                                                            |
+| wm.program.launcher.window     | Command i3 executes for the window navigation keybinding                                                                                                                                            |
+| wm.program.help                | Command to launch from the help keybinding                                                                                                                                                          |
+| wm.program.file_search         | Command to launch from the file search keybinding                                                                                                                                                   |
+| wm.program.refresh_ui          | Command to launch from the session refresh keybinding                                                                                                                                               |
+| wm.program.logout              | Command to launch from the logout keybinding                                                                                                                                                        |
+| wm.program.reboot              | Command to launch from the reboot keybinding                                                                                                                                                        |
+| wm.program.shutdown            | Command to launch from the shutdown keybinding                                                                                                                                                      |
+| wm.program.lock                | Command to launch from the lock screen keybinding                                                                                                                                                   |
+| wm.program.sleep               | Command to launch from the sleep keybinding                                                                                                                                                         |
+| wm.program.settings            | Command to launch from the Control Panel keybinding                                                                                                                                                 |
+| wm.program.display             | Command to launch from the Display Settings keybinding                                                                                                                                              |
+| wm.program.wifi                | Command to launch from the Wifi Settings keybinding                                                                                                                                                 |
+| wm.program.bluetooth           | Command to launch from the Bluetooth Settings keybinding                                                                                                                                            |
+| wm.program.files               | Command to launch from the file browser keybinding                                                                                                                                                  |
+| wm.program.notification_ui     | Command to launch from the notification UI keybinding                                                                                                                                               |
+| wm.program.1...wm.program.3 | Optional programs to start with i3                                                                                                                                                                  |
 | i3xrocks.media-player.player-args | Optional arguments used by the `media-player` i3xrocks block. These arguments are fed straight into `playerctl`, eg. setting this value to `-p spotify` only makes the bar display/control spotify. |
 | i3xrocks.action.mic.left | Optional command to run on left button click of microphone status indicator. |
 | i3xrocks.action.mic.middle | Optional command to run on middle button click of microphone status indicator. |

--- a/content/docs/reference/xresources.fr.md
+++ b/content/docs/reference/xresources.fr.md
@@ -6,6 +6,10 @@ description: >
   Toutes les clés `Xresources` disponibles pour Regolith
 ---
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 | `Xresources` Key                                   | Description                                                                                                                   |
 | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | gtk.theme_name                                     | GTK Theme                                                                                                                     |
@@ -20,52 +24,52 @@ description: >
 | gnome.terminal.use-transparent-background          | Enables transparent background in gnome-terminal (`true / false`). See also `gnome.terminal.background-transparency-percent`. |
 | gnome.wallpaper                                    | GNOME Wallpaper (can be overridden in Settings)                                                                               |
 | gnome.wm.theme                                     | GNOME Window Manager Theme (unused)                                                                                           |
-| i3-wm.alt                                          | Key mapping for Alt key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.                 |
-| i3-wm.bar.background.color                         | Bar Background Color                                                                                                          |
-| i3-wm.bar.position                                 | Bar Screen Position                                                                                                           |
-| i3-wm.bar.separator.color                          | Color of seperator between blocks                                                                                             |
-| i3-wm.bar.statusline.color                         |                                                                                                                               |
-| i3-wm.bar.trayoutput                               | Enable or disable the [app tray](https://i3wm.org/docs/userguide.html#_tray_output) in i3bar                                  |
-| i3-wm.bar.workspace.active.background.color        |                                                                                                                               |
-| i3-wm.bar.workspace.active.border.color            |                                                                                                                               |
-| i3-wm.bar.workspace.active.text.color              |                                                                                                                               |
-| i3-wm.bar.workspace.focused.background.color       |                                                                                                                               |
-| i3-wm.bar.workspace.focused.border.color           |                                                                                                                               |
-| i3-wm.bar.workspace.focused.text.color             |                                                                                                                               |
-| i3-wm.bar.workspace.inactive.background.color      |                                                                                                                               |
-| i3-wm.bar.workspace.inactive.border.color          |                                                                                                                               |
-| i3-wm.bar.workspace.inactive.text.color            |                                                                                                                               |
-| i3-wm.bar.workspace.urgent.background.color        |                                                                                                                               |
-| i3-wm.bar.workspace.urgent.border.color            |                                                                                                                               |
-| i3-wm.bar.workspace.urgent.text.color              |                                                                                                                               |
-| i3-wm.client.focused.color.background              |                                                                                                                               |
-| i3-wm.client.focused.color.border                  |                                                                                                                               |
-| i3-wm.client.focused.color.child_border            |                                                                                                                               |
-| i3-wm.client.focused.color.indicator               |                                                                                                                               |
-| i3-wm.client.focused.color.text                    |                                                                                                                               |
-| i3-wm.client.focused_inactive.color.background     |                                                                                                                               |
-| i3-wm.client.focused_inactive.color.border         |                                                                                                                               |
-| i3-wm.client.focused_inactive.color.child_border   |                                                                                                                               |
-| i3-wm.client.focused_inactive.color.indicator      |                                                                                                                               |
-| i3-wm.client.focused_inactive.color.text           |                                                                                                                               |
-| i3-wm.client.unfocused.color.background            |                                                                                                                               |
-| i3-wm.client.unfocused.color.border                |                                                                                                                               |
-| i3-wm.client.unfocused.color.child_border          |                                                                                                                               |
-| i3-wm.client.unfocused.color.indicator             |                                                                                                                               |
-| i3-wm.client.unfocused.color.text                  |                                                                                                                               |
-| i3-wm.client.urgent.color.background               |                                                                                                                               |
-| i3-wm.client.urgent.color.border                   |                                                                                                                               |
-| i3-wm.client.urgent.color.child_border             |                                                                                                                               |
-| i3-wm.client.urgent.color.indicator                |                                                                                                                               |
-| i3-wm.client.urgent.color.text                     |                                                                                                                               |
-| i3-wm.floatingwindow.border.size                   | Window border size in pixels for floating windows                                                                             |
-| i3-wm.font                                         | Window manager font                                                                                                           |
-| i3-wm.gaps.inner.size                              | Default gap size between windows in pixels                                                                                    |
-| i3-wm.gaps.outer.size                              | Default gap size at screen edge in pixels                                                                                     |
-| i3-wm.mod                                          | Key mapping for Super key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.               |
-| i3-wm.window.border.size                           | Default border size in pixels                                                                                                 |
-| i3-wm.workspace.01.name .. i3-wm.workspace.19.name | Workspace Labels                                                                                                              |
-| i3-wm.workspace.01.key .. i3-wm.workspace.10.key   | Workspace Shortucts                                                                                                           |
+| wm.alt                                          | Key mapping for Alt key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.                 |
+| wm.bar.background.color                         | Bar Background Color                                                                                                          |
+| wm.bar.position                                 | Bar Screen Position                                                                                                           |
+| wm.bar.separator.color                          | Color of seperator between blocks                                                                                             |
+| wm.bar.statusline.color                         |                                                                                                                               |
+| wm.bar.trayoutput                               | Enable or disable the [app tray](https://i3wm.org/docs/userguide.html#_tray_output) in i3bar                                  |
+| wm.bar.workspace.active.background.color        |                                                                                                                               |
+| wm.bar.workspace.active.border.color            |                                                                                                                               |
+| wm.bar.workspace.active.text.color              |                                                                                                                               |
+| wm.bar.workspace.focused.background.color       |                                                                                                                               |
+| wm.bar.workspace.focused.border.color           |                                                                                                                               |
+| wm.bar.workspace.focused.text.color             |                                                                                                                               |
+| wm.bar.workspace.inactive.background.color      |                                                                                                                               |
+| wm.bar.workspace.inactive.border.color          |                                                                                                                               |
+| wm.bar.workspace.inactive.text.color            |                                                                                                                               |
+| wm.bar.workspace.urgent.background.color        |                                                                                                                               |
+| wm.bar.workspace.urgent.border.color            |                                                                                                                               |
+| wm.bar.workspace.urgent.text.color              |                                                                                                                               |
+| wm.client.focused.color.background              |                                                                                                                               |
+| wm.client.focused.color.border                  |                                                                                                                               |
+| wm.client.focused.color.child_border            |                                                                                                                               |
+| wm.client.focused.color.indicator               |                                                                                                                               |
+| wm.client.focused.color.text                    |                                                                                                                               |
+| wm.client.focused_inactive.color.background     |                                                                                                                               |
+| wm.client.focused_inactive.color.border         |                                                                                                                               |
+| wm.client.focused_inactive.color.child_border   |                                                                                                                               |
+| wm.client.focused_inactive.color.indicator      |                                                                                                                               |
+| wm.client.focused_inactive.color.text           |                                                                                                                               |
+| wm.client.unfocused.color.background            |                                                                                                                               |
+| wm.client.unfocused.color.border                |                                                                                                                               |
+| wm.client.unfocused.color.child_border          |                                                                                                                               |
+| wm.client.unfocused.color.indicator             |                                                                                                                               |
+| wm.client.unfocused.color.text                  |                                                                                                                               |
+| wm.client.urgent.color.background               |                                                                                                                               |
+| wm.client.urgent.color.border                   |                                                                                                                               |
+| wm.client.urgent.color.child_border             |                                                                                                                               |
+| wm.client.urgent.color.indicator                |                                                                                                                               |
+| wm.client.urgent.color.text                     |                                                                                                                               |
+| wm.floatingwindow.border.size                   | Window border size in pixels for floating windows                                                                             |
+| wm.font                                         | Window manager font                                                                                                           |
+| wm.gaps.inner.size                              | Default gap size between windows in pixels                                                                                    |
+| wm.gaps.outer.size                              | Default gap size at screen edge in pixels                                                                                     |
+| wm.mod                                          | Key mapping for Super key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.               |
+| wm.window.border.size                           | Default border size in pixels                                                                                                 |
+| wm.workspace.01.name .. wm.workspace.19.name | Workspace Labels                                                                                                              |
+| wm.workspace.01.key .. wm.workspace.10.key   | Workspace Shortucts                                                                                                           |
 | i3xrocks.action.volume.left                        | Command to execute when volume indicator is left clicked (default: none)                                                      |
 | i3xrocks.action.volume.middle                      | Command to execute when volume indicator is middle clicked (default: none)                                                    |
 | i3xrocks.action.volume.right                       | Command to execute when volume indicator is right clicked (default: mute through amixer)                                      |
@@ -113,25 +117,25 @@ The following `Xresources` keys are undefined by default but can be used by user
 
 | `Xresources` Key                    | Description                                                                                                                                                                                         |
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| i3-wm.gaps.focus_follows_mouse      | The window under the mouse has focus if enabled                                                                                                                                                     |
-| i3-wm.program.launcher.app          | Command i3 executes from the app launcher keybinding                                                                                                                                                |
-| i3-wm.program.launcher.cmd          | Command i3 executes from the command launcher keybinding                                                                                                                                            |
-| i3-wm.program.launcher.window       | Command i3 executes for the window navigation keybinding                                                                                                                                            |
-| i3-wm.program.help                  | Command to launch from the help keybinding                                                                                                                                                          |
-| i3-wm.program.file_search           | Command to launch from the file search keybinding                                                                                                                                                   |
-| i3-wm.program.refresh_ui            | Command to launch from the session refresh keybinding                                                                                                                                               |
-| i3-wm.program.logout                | Command to launch from the logout keybinding                                                                                                                                                        |
-| i3-wm.program.reboot                | Command to launch from the reboot keybinding                                                                                                                                                        |
-| i3-wm.program.shutdown              | Command to launch from the shutdown keybinding                                                                                                                                                      |
-| i3-wm.program.lock                  | Command to launch from the lock screen keybinding                                                                                                                                                   |
-| i3-wm.program.sleep                 | Command to launch from the sleep keybinding                                                                                                                                                         |
-| i3-wm.program.settings              | Command to launch from the Control Panel keybinding                                                                                                                                                 |
-| i3-wm.program.display               | Command to launch from the Display Settings keybinding                                                                                                                                              |
-| i3-wm.program.wifi                  | Command to launch from the Wifi Settings keybinding                                                                                                                                                 |
-| i3-wm.program.bluetooth             | Command to launch from the Bluetooth Settings keybinding                                                                                                                                            |
-| i3-wm.program.files                 | Command to launch from the file browser keybinding                                                                                                                                                  |
-| i3-wm.program.notification_ui       | Command to launch from the notification UI keybinding                                                                                                                                               |
-| i3-wm.program.1...i3-wm.program.3   | Optional programs to start with i3                                                                                                                                                                  |
+| wm.gaps.focus_follows_mouse      | The window under the mouse has focus if enabled                                                                                                                                                     |
+| wm.program.launcher.app          | Command i3 executes from the app launcher keybinding                                                                                                                                                |
+| wm.program.launcher.cmd          | Command i3 executes from the command launcher keybinding                                                                                                                                            |
+| wm.program.launcher.window       | Command i3 executes for the window navigation keybinding                                                                                                                                            |
+| wm.program.help                  | Command to launch from the help keybinding                                                                                                                                                          |
+| wm.program.file_search           | Command to launch from the file search keybinding                                                                                                                                                   |
+| wm.program.refresh_ui            | Command to launch from the session refresh keybinding                                                                                                                                               |
+| wm.program.logout                | Command to launch from the logout keybinding                                                                                                                                                        |
+| wm.program.reboot                | Command to launch from the reboot keybinding                                                                                                                                                        |
+| wm.program.shutdown              | Command to launch from the shutdown keybinding                                                                                                                                                      |
+| wm.program.lock                  | Command to launch from the lock screen keybinding                                                                                                                                                   |
+| wm.program.sleep                 | Command to launch from the sleep keybinding                                                                                                                                                         |
+| wm.program.settings              | Command to launch from the Control Panel keybinding                                                                                                                                                 |
+| wm.program.display               | Command to launch from the Display Settings keybinding                                                                                                                                              |
+| wm.program.wifi                  | Command to launch from the Wifi Settings keybinding                                                                                                                                                 |
+| wm.program.bluetooth             | Command to launch from the Bluetooth Settings keybinding                                                                                                                                            |
+| wm.program.files                 | Command to launch from the file browser keybinding                                                                                                                                                  |
+| wm.program.notification_ui       | Command to launch from the notification UI keybinding                                                                                                                                               |
+| wm.program.1...wm.program.3   | Optional programs to start with i3                                                                                                                                                                  |
 | i3xrocks.media-player.player-args   | Optional arguments used by the `media-player` i3xrocks block. These arguments are fed straight into `playerctl`, eg. setting this value to `-p spotify` only makes the bar display/control spotify. |
 | i3xrocks.action.mic.left            | Optional command to run on left button click of microphone status indicator.                                                                                                                        |
 | i3xrocks.action.mic.middle          | Optional command to run on middle button click of microphone status indicator.                                                                                                                      |

--- a/content/docs/reference/xresources.md
+++ b/content/docs/reference/xresources.md
@@ -6,6 +6,10 @@ description: >
   All Regolith `Xresources` key definitions
 ---
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 | `Xresources` Key                                   | Description                                                                                                         |
 | -------------------------------------------------- | ------------------------------------------------------------------- |
 | gtk.theme_name                                     | GTK Theme   |
@@ -20,53 +24,53 @@ description: >
 | gnome.terminal.use-transparent-background          | Enables transparent background in gnome-terminal (`true / false`). See also `gnome.terminal.background-transparency-percent`. |
 | gnome.wallpaper                                    | GNOME Wallpaper (can be overridden in Settings)                                                                     |
 | gnome.wm.theme                                     | GNOME Window Manager Theme (unused)                                                                                 |
-| i3-wm.alt                                          | Key mapping for Alt key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.       |
-| i3-wm.bar.background.color                         | Bar Background Color                                                                                                |
-| i3-wm.bar.position                                 | Bar Screen Position                                                                                                 |
-| i3-wm.bar.separator.color                          | Color of seperator between blocks                                                                                   |
-| i3-wm.bar.separatorchar                            | Character to display between blocks                                                                                 |
-| i3-wm.bar.statusline.color                         |                                                                                                                     |
-| i3-wm.bar.trayoutput                               | Enable or disable the [app tray](https://i3wm.org/docs/userguide.html#_tray_output) in i3bar                        |
-| i3-wm.bar.workspace.active.background.color        |                                                                                                                     |
-| i3-wm.bar.workspace.active.border.color            |                                                                                                                     |
-| i3-wm.bar.workspace.active.text.color              |                                                                                                                     |
-| i3-wm.bar.workspace.focused.background.color       |                                                                                                                     |
-| i3-wm.bar.workspace.focused.border.color           |                                                                                                                     |
-| i3-wm.bar.workspace.focused.text.color             |                                                                                                                     |
-| i3-wm.bar.workspace.inactive.background.color      |                                                                                                                     |
-| i3-wm.bar.workspace.inactive.border.color          |                                                                                                                     |
-| i3-wm.bar.workspace.inactive.text.color            |                                                                                                                     |
-| i3-wm.bar.workspace.urgent.background.color        |                                                                                                                     |
-| i3-wm.bar.workspace.urgent.border.color            |                                                                                                                     |
-| i3-wm.bar.workspace.urgent.text.color              |                                                                                                                     |
-| i3-wm.client.focused.color.background              |                                                                                                                     |
-| i3-wm.client.focused.color.border                  |                                                                                                                     |
-| i3-wm.client.focused.color.child_border            |                                                                                                                     |
-| i3-wm.client.focused.color.indicator               |                                                                                                                     |
-| i3-wm.client.focused.color.text                    |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.background     |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.border         |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.child_border   |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.indicator      |                                                                                                                     |
-| i3-wm.client.focused_inactive.color.text           |                                                                                                                     |
-| i3-wm.client.unfocused.color.background            |                                                                                                                     |
-| i3-wm.client.unfocused.color.border                |                                                                                                                     |
-| i3-wm.client.unfocused.color.child_border          |                                                                                                                     |
-| i3-wm.client.unfocused.color.indicator             |                                                                                                                     |
-| i3-wm.client.unfocused.color.text                  |                                                                                                                     |
-| i3-wm.client.urgent.color.background               |                                                                                                                     |
-| i3-wm.client.urgent.color.border                   |                                                                                                                     |
-| i3-wm.client.urgent.color.child_border             |                                                                                                                     |
-| i3-wm.client.urgent.color.indicator                |                                                                                                                     |
-| i3-wm.client.urgent.color.text                     |                                                                                                                     |
-| i3-wm.floatingwindow.border.size                   | Window border size in pixels for floating windows                                                                   |
-| i3-wm.font                                         | Window manager font                                                                                                 |
-| i3-wm.gaps.inner.size                              | Default gap size between windows in pixels                                                                          |
-| i3-wm.gaps.outer.size                              | Default gap size at screen edge in pixels                                                                           |
-| i3-wm.mod                                          | Key mapping for Super key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.     |
-| i3-wm.window.border.size                           | Default border size in pixels                                                                                       |
-| i3-wm.workspace.01.name .. i3-wm.workspace.19.name | Workspace Labels                                                                                                    |
-| i3-wm.workspace.01.key .. i3-wm.workspace.10.key   | Workspace Shortucts                                                                                                 |
+| wm.alt                                          | Key mapping for Alt key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.       |
+| wm.bar.background.color                         | Bar Background Color                                                                                                |
+| wm.bar.position                                 | Bar Screen Position                                                                                                 |
+| wm.bar.separator.color                          | Color of seperator between blocks                                                                                   |
+| wm.bar.separatorchar                            | Character to display between blocks                                                                                 |
+| wm.bar.statusline.color                         |                                                                                                                     |
+| wm.bar.trayoutput                               | Enable or disable the [app tray](https://i3wm.org/docs/userguide.html#_tray_output) in i3bar                        |
+| wm.bar.workspace.active.background.color        |                                                                                                                     |
+| wm.bar.workspace.active.border.color            |                                                                                                                     |
+| wm.bar.workspace.active.text.color              |                                                                                                                     |
+| wm.bar.workspace.focused.background.color       |                                                                                                                     |
+| wm.bar.workspace.focused.border.color           |                                                                                                                     |
+| wm.bar.workspace.focused.text.color             |                                                                                                                     |
+| wm.bar.workspace.inactive.background.color      |                                                                                                                     |
+| wm.bar.workspace.inactive.border.color          |                                                                                                                     |
+| wm.bar.workspace.inactive.text.color            |                                                                                                                     |
+| wm.bar.workspace.urgent.background.color        |                                                                                                                     |
+| wm.bar.workspace.urgent.border.color            |                                                                                                                     |
+| wm.bar.workspace.urgent.text.color              |                                                                                                                     |
+| wm.client.focused.color.background              |                                                                                                                     |
+| wm.client.focused.color.border                  |                                                                                                                     |
+| wm.client.focused.color.child_border            |                                                                                                                     |
+| wm.client.focused.color.indicator               |                                                                                                                     |
+| wm.client.focused.color.text                    |                                                                                                                     |
+| wm.client.focused_inactive.color.background     |                                                                                                                     |
+| wm.client.focused_inactive.color.border         |                                                                                                                     |
+| wm.client.focused_inactive.color.child_border   |                                                                                                                     |
+| wm.client.focused_inactive.color.indicator      |                                                                                                                     |
+| wm.client.focused_inactive.color.text           |                                                                                                                     |
+| wm.client.unfocused.color.background            |                                                                                                                     |
+| wm.client.unfocused.color.border                |                                                                                                                     |
+| wm.client.unfocused.color.child_border          |                                                                                                                     |
+| wm.client.unfocused.color.indicator             |                                                                                                                     |
+| wm.client.unfocused.color.text                  |                                                                                                                     |
+| wm.client.urgent.color.background               |                                                                                                                     |
+| wm.client.urgent.color.border                   |                                                                                                                     |
+| wm.client.urgent.color.child_border             |                                                                                                                     |
+| wm.client.urgent.color.indicator                |                                                                                                                     |
+| wm.client.urgent.color.text                     |                                                                                                                     |
+| wm.floatingwindow.border.size                   | Window border size in pixels for floating windows                                                                   |
+| wm.font                                         | Window manager font                                                                                                 |
+| wm.gaps.inner.size                              | Default gap size between windows in pixels                                                                          |
+| wm.gaps.outer.size                              | Default gap size at screen edge in pixels                                                                           |
+| wm.mod                                          | Key mapping for Super key. See the [i3 User Guide](https://i3wm.org/docs/userguide.html#_using_i3) for details.     |
+| wm.window.border.size                           | Default border size in pixels                                                                                       |
+| wm.workspace.01.name .. wm.workspace.19.name | Workspace Labels                                                                                                    |
+| wm.workspace.01.key .. wm.workspace.10.key   | Workspace Shortucts                                                                                                 |
 | i3xrocks.action.volume.left                        | Command to execute when volume indicator is left clicked (default: none)                                            |
 | i3xrocks.action.volume.middle                      | Command to execute when volume indicator is middle clicked (default: none)                                          |
 | i3xrocks.action.volume.right                       | Command to execute when volume indicator is right clicked (default: mute through amixer)                            |
@@ -114,25 +118,25 @@ The following `Xresources` keys are undefined by default but can be used by user
 
 | `Xresources` Key                  | Description                                                                                                                                                                                         |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| i3-wm.gaps.focus_follows_mouse    | The window under the mouse has focus if enabled                                                                                                                                                     |
-| i3-wm.program.launcher.app        | Command i3 executes from the app launcher keybinding                                                                                                                                                |
-| i3-wm.program.launcher.cmd        | Command i3 executes from the command launcher keybinding                                                                                                                                            |
-| i3-wm.program.launcher.window     | Command i3 executes for the window navigation keybinding                                                                                                                                            |
-| i3-wm.program.help                | Command to launch from the help keybinding                                                                                                                                                          |
-| i3-wm.program.file_search         | Command to launch from the file search keybinding                                                                                                                                                   |
-| i3-wm.program.refresh_ui          | Command to launch from the session refresh keybinding                                                                                                                                               |
-| i3-wm.program.logout              | Command to launch from the logout keybinding                                                                                                                                                        |
-| i3-wm.program.reboot              | Command to launch from the reboot keybinding                                                                                                                                                        |
-| i3-wm.program.shutdown            | Command to launch from the shutdown keybinding                                                                                                                                                      |
-| i3-wm.program.lock                | Command to launch from the lock screen keybinding                                                                                                                                                   |
-| i3-wm.program.sleep               | Command to launch from the sleep keybinding                                                                                                                                                         |
-| i3-wm.program.settings            | Command to launch from the Control Panel keybinding                                                                                                                                                 |
-| i3-wm.program.display             | Command to launch from the Display Settings keybinding                                                                                                                                              |
-| i3-wm.program.wifi                | Command to launch from the Wifi Settings keybinding                                                                                                                                                 |
-| i3-wm.program.bluetooth           | Command to launch from the Bluetooth Settings keybinding                                                                                                                                            |
-| i3-wm.program.files               | Command to launch from the file browser keybinding                                                                                                                                                  |
-| i3-wm.program.notification_ui     | Command to launch from the notification UI keybinding                                                                                                                                               |
-| i3-wm.program.1...i3-wm.program.3 | Optional programs to start with i3                                                                                                                                                                  |
+| wm.gaps.focus_follows_mouse    | The window under the mouse has focus if enabled                                                                                                                                                     |
+| wm.program.launcher.app        | Command i3 executes from the app launcher keybinding                                                                                                                                                |
+| wm.program.launcher.cmd        | Command i3 executes from the command launcher keybinding                                                                                                                                            |
+| wm.program.launcher.window     | Command i3 executes for the window navigation keybinding                                                                                                                                            |
+| wm.program.help                | Command to launch from the help keybinding                                                                                                                                                          |
+| wm.program.file_search         | Command to launch from the file search keybinding                                                                                                                                                   |
+| wm.program.refresh_ui          | Command to launch from the session refresh keybinding                                                                                                                                               |
+| wm.program.logout              | Command to launch from the logout keybinding                                                                                                                                                        |
+| wm.program.reboot              | Command to launch from the reboot keybinding                                                                                                                                                        |
+| wm.program.shutdown            | Command to launch from the shutdown keybinding                                                                                                                                                      |
+| wm.program.lock                | Command to launch from the lock screen keybinding                                                                                                                                                   |
+| wm.program.sleep               | Command to launch from the sleep keybinding                                                                                                                                                         |
+| wm.program.settings            | Command to launch from the Control Panel keybinding                                                                                                                                                 |
+| wm.program.display             | Command to launch from the Display Settings keybinding                                                                                                                                              |
+| wm.program.wifi                | Command to launch from the Wifi Settings keybinding                                                                                                                                                 |
+| wm.program.bluetooth           | Command to launch from the Bluetooth Settings keybinding                                                                                                                                            |
+| wm.program.files               | Command to launch from the file browser keybinding                                                                                                                                                  |
+| wm.program.notification_ui     | Command to launch from the notification UI keybinding                                                                                                                                               |
+| wm.program.1...wm.program.3 | Optional programs to start with i3                                                                                                                                                                  |
 | i3xrocks.media-player.player-args | Optional arguments used by the `media-player` i3xrocks block. These arguments are fed straight into `playerctl`, eg. setting this value to `-p spotify` only makes the bar display/control spotify. |
 | i3xrocks.action.mic.left | Optional command to run on left button click of microphone status indicator. |
 | i3xrocks.action.mic.middle | Optional command to run on middle button click of microphone status indicator. |

--- a/content/docs/using-regolith/configuration.de.md
+++ b/content/docs/using-regolith/configuration.de.md
@@ -209,6 +209,10 @@ Im Folgenden finden Sie eine Liste aller i3-Konfigurationspakete, die in Regolit
 
 # Tastaturbelegungen
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 Die häufigste Änderung der Tastaturbelegung ist die Taste {{< keys "super" >}}. Regolith verwendet `Xresources` als
 kanonische Quelle für Einstellungen, die von verschiedenen UI-Komponenten gelesen werden. Die Tabelle der `Xresources`
 -Parameter, für die Benutzerkonfiguration [ist an anderer Stelle verfügbar]({{< ref "xresources" >}}). Um die
@@ -216,8 +220,8 @@ Tastaturbelegung {{< keys "super" >}} von der Taste "windows" auf "alt" zu ände
 Datei `~/.config/regolith3/Xresources` ein:
 
 ```toml
-i3-wm.mod: Mod1
-i3-wm.alt: Mod4
+wm.mod: Mod1
+wm.alt: Mod4
 ```
 
 **Anmerkung**: GNOME hat auch seinen eigenen Satz von Tastaturbelegungen. Wenn die Regolith-Sitzung zum ersten Mal

--- a/content/docs/using-regolith/configuration.fr.md
+++ b/content/docs/using-regolith/configuration.fr.md
@@ -213,14 +213,18 @@ La liste suivante contient tous les paquets de configuration pour i3 disponibles
 
 # Raccourcis clavier
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 La modification la plus courante est la touche {{< keys "super" >}}.
 Regolith utilise `Xresources` comme une source de vérité pour les paramètres, qui sont lu par divers composants de l'UI.
 La table des valeurs `Xresources` accessibles à l'utilisateur est [accessible ailleurs]({{< ref "xresources" >}}).
 Pour changer la touche par défaut {{< keys "super" >}} (touche "Win") pour la touche "Alt", ajoutez la configuration suivante au fichier `~/.config/regolith3/Xresources`:
 
 ```toml
-i3-wm.mod: Mod1
-i3-wm.alt: Mod4
+wm.mod: Mod1
+wm.alt: Mod4
 ```
 
 **Note**: GNOME utilise aussi ses propres raccourcis clavier. Quand la session Regolith est initialisée, les conflits de raccourcis avec GNOME sont supprimés

--- a/content/docs/using-regolith/configuration.md
+++ b/content/docs/using-regolith/configuration.md
@@ -225,11 +225,15 @@ The following contains a list of all i3 configuration packages available in Rego
 
 # Keybindings
 
+{{< hint warning >}}
+Regolith version 3.0 onward replaces "i3-wm" with "wm" in Xresource keys.  The content on this page has been updated for Regolith 3.0+.  If you are using an earlier version, use "i3-wm" instead of "wm" in the key names below.  For example `wm.foo.bar` changes to `i3-wm.foo.bar` for Regolith 1.x and 2.x.
+{{< /hint >}}
+
 The most common keybinding change is the {{< keys "super" >}} key. Regolith uses `Xresources` as the canonical source of truth for settings, which are read by various UI components. The table of `Xresources` keys open to user configuration [is available elsewhere]({{< ref "xresources" >}}). To change the default {{< keys "super" >}} binding from the "windows" key to "alt", add the following line to the file `~/.config/regolith3/Xresources`:
 
 ```toml
-i3-wm.mod: Mod1
-i3-wm.alt: Mod4
+wm.mod: Mod1
+wm.alt: Mod4
 ```
 
 **Note**: GNOME also has its own set of keybindings. When the Regolith session is first initialized, the conflicting GNOME keybindings are removed from the user settings. GNOME keybindings can be managed in the Regolith Settings app.


### PR DESCRIPTION
Update all docs to reference 3.x key names 'wm' rather than deprecated form of 'i3-wm'