### PR TITLE
Feature/add sway specific tutorials

### DIFF
--- a/content/docs/howtos/multiple-batteries.md
+++ b/content/docs/howtos/multiple-batteries.md
@@ -3,7 +3,7 @@ title: "Support Multiple Batteries"
 description: >
   Display status of the batteries per instance
 ---
-
+# i3
 {{< hint danger >}}
 NOTICE: This page was copied from the [Regolith 1.x website](https://regolith-linux.org) and has not been updated for Regolith 2.  It may contain out of date information.
 {{< /hint >}}
@@ -45,6 +45,45 @@ instance=BAT0
 interval=30
 instance=BAT1
 ```
+
+## Sway
+
+1. Stage your i3status-rust config file:
+```sh
+cp /etc/regolith/i3status-rust/config.toml ~/.config/regolith3/i3status-rust/config.toml
+```
+
+2. Configure to supply i3status-rust with your config file:
+```sh
+echo "wm.bar.status_config: ~/.config/regolith3/i3status-rust/config.toml" >> ~/.config/regolith3/Xresources
+```
+
+3. List all the battery instances running on your machine by running:
+
+```sh
+ls /sys/class/power_supply/
+
+# AC BAT0 BAT1
+```
+
+4. Update the staged config file to contain blocks for both of the batteries:
+
+```conf
+[[block]]
+block = "battery"
+interval = 10
+[...]
+device = "BAT0"
+
+[[block]]
+block = "battery"
+interval = 10
+[...]
+device = "BAT1"
+
+```
+
+
 
 ## Further Reading
 

--- a/content/docs/howtos/workspace-on-output.md
+++ b/content/docs/howtos/workspace-on-output.md
@@ -3,7 +3,7 @@ title: "Assign a workspace to a specific Output (Display)"
 description: >
   Specify that a given workspace should always be displayed on a specific monitor
 ---
-
+## i3
 {{< hint danger >}}
 NOTICE: This page was copied from the [Regolith 1.x website](https://regolith-linux.org) and has not been updated for Regolith 2.  It may contain out of date information.
 {{< /hint >}}
@@ -23,3 +23,19 @@ workspace "$ws1" output DP1
 ```
 
 Log back in for the changes to take effect.
+
+
+## Sway
+The concept is the same, but `swaymsg` is used to display the available outputs.
+
+```console
+$ swaymsg -t get_outputs
+Output HDMI-A-2 'ViewSonic Corporation VG2448 V5E192121969' 
+[...]
+```
+
+To assign workspace *$ws1* to the HDMI-A-2 output put the following line into [a staged copy of your sway config file]({{< ref "stage-configs">}}):
+
+```
+workspace $ws1 output HDMI-A-2
+```


### PR DESCRIPTION
While setting up regolith with sway/wayland I realized that the tutorials do not mention sway specifics/differences. This PR contains my solutions that I found for two tutorials. Let me know if I should adapt the formatting somehow! 

cc: @kgilmer 